### PR TITLE
Fix: Correct indentation in main.py to resolve black formatting error

### DIFF
--- a/main.py
+++ b/main.py
@@ -414,7 +414,7 @@ async def place_order_projectx(alert: SignalAlert, strategy_cfg: dict):
     order_side = "buy" if alert.signal.lower() == "long" else "sell"
 
     # Initialize with common parameters
-pydantic_request_params = {
+    pydantic_request_params = {
         "account_id": order_account_id,
         "contract_id": order_contract_id,
         "qty": order_quantity,


### PR DESCRIPTION
The `black` formatter was failing during deployment due to a parsing error in `main.py` at line 425. This was caused by incorrect indentation of the `pydantic_request_params` dictionary initialization and its subsequent conditional logic within the `place_order_projectx` function.

This commit corrects the indentation, ensuring the block is properly scoped within the function, which resolves the parsing error.