### PR TITLE
Fix: Make Account schema fields optional to prevent parsing errors

### DIFF
--- a/topstep_client/schemas.py
+++ b/topstep_client/schemas.py
@@ -15,12 +15,12 @@ class TokenResponse(BaseSchema):
 
 class Account(BaseSchema):
     id: int
-    name: str
+    name: Optional[str] = None
     user_id: int = Field(..., alias='userId')
-    account_type: str = Field(..., alias='accountType') # e.g., "Evaluation", "Funded"
+    account_type: Optional[str] = Field(default=None, alias='accountType')
     balance: float
     currency: str
-    active: bool
+    active: Optional[bool] = None
     # Add other relevant fields based on API response
 
 class Contract(BaseSchema):


### PR DESCRIPTION
The application was encountering a "Failed to parse account data" error, likely due to the `Account` Pydantic model expecting fields that were not consistently present or had type mismatches in the API response from `/api/Account/search`.

This commit modifies the `Account` schema in `topstep_client/schemas.py` to make the `name`, `account_type`, and `active` fields optional. This change increases the resilience of the account data parsing logic by allowing these fields to be absent in the API response without triggering a validation error.