### PR TITLE
Fix: Make userId and currency optional in Account schema

### DIFF
--- a/topstep_client/schemas.py
+++ b/topstep_client/schemas.py
@@ -16,10 +16,10 @@ class TokenResponse(BaseSchema):
 class Account(BaseSchema):
     id: int
     name: Optional[str] = None
-    user_id: int = Field(..., alias='userId')
+    user_id: Optional[int] = Field(default=None, alias='userId')
     account_type: Optional[str] = Field(default=None, alias='accountType')
     balance: float
-    currency: str
+    currency: Optional[str] = None
     active: Optional[bool] = None
     # Add other relevant fields based on API response
 


### PR DESCRIPTION
Based on detailed error logs, the "Failed to parse account data" error was caused by the `userId` and `currency` fields being absent from some account data items returned by the API. These fields were previously marked as required in the `Account` Pydantic model.

This commit updates the `Account` schema in `topstep_client/schemas.py` to make `user_id` (aliased as `userId`) and `currency` optional. This change will prevent parsing errors when these fields are not included in the API response for an account.