### PR TITLE
Fix: Correct stream token factory to provide string token

### DIFF
--- a/topstep_client/streams.py
+++ b/topstep_client/streams.py
@@ -129,8 +129,8 @@ class BaseStream:
 
                 self._connection = HubConnectionBuilder() \
                     .with_url(hub_url, options={
-                        "access_token_factory": lambda: self._ensure_token(),
-                        "skip_negotiation": True # As per tsxapi4py
+                        "access_token_factory": lambda: self._current_token, # Changed line
+                        "skip_negotiation": True
                     }) \
                     .with_automatic_reconnect({
                         "type": "interval",


### PR DESCRIPTION
The streams were failing to connect due to a TypeError: "can only concatenate str (not "coroutine") to str". This occurred because the `access_token_factory` provided to `signalrcore` was `lambda: self._ensure_token()`, where `_ensure_token` is an async method. The `signalrcore` library was not awaiting the coroutine returned by the factory, leading to the error when it tried to use the coroutine object as a string.

This commit modifies `BaseStream.start()` in `topstep_client/streams.py` to change the `access_token_factory` to `lambda: self._current_token`. The `self._current_token` attribute is already populated with the awaited string token (via `await self._ensure_token()`) immediately before the `HubConnectionBuilder` is configured.

This ensures that the factory provides a string token directly, resolving the TypeError and allowing streams to authenticate correctly.