### PR TITLE
Feat: Add manual trade entry page with order and account actions

### DIFF
--- a/topstep_client/api_client.py
+++ b/topstep_client/api_client.py
@@ -1,11 +1,25 @@
 import httpx
 import os
 import logging
+import asyncio # Added asyncio
 from datetime import datetime, timedelta
 from typing import Optional, Type, TypeVar, Any, Dict, Union, List
 from pydantic import BaseModel, ValidationError # Ensure BaseModel is imported if used in type hints
 
-from .schemas import TokenResponse, Account, Contract, OrderRequest, OrderDetails, APIResponse, ErrorDetail, BaseSchema, BarData, HistoricalBarsResponse
+from .schemas import (
+    TokenResponse,
+    Account,
+    Contract,
+    OrderRequest,
+    OrderDetails,
+    APIResponse,
+    ErrorDetail,
+    BaseSchema,
+    BarData,
+    HistoricalBarsResponse,
+    OpenOrderSchema, # Added
+    PositionSchema   # Added
+)
 from .exceptions import AuthenticationError, APIRequestError, APIResponseParsingError, TopstepAPIError
 
 logger = logging.getLogger(__name__)
@@ -478,6 +492,37 @@ class APIClient:
         except ValidationError as e:
             logger.error(f"Pydantic validation error parsing historical bars: {e}. Raw response: {raw_response if 'raw_response' in locals() else 'N/A'}")
             raise APIResponseParsingError("Failed to parse historical bars response.", raw_response_text=str(raw_response if 'raw_response' in locals() else 'N/A'), original_exception=e) from e
+
+    async def get_open_orders(self, account_id: int) -> List[OpenOrderSchema]:
+        logger.info(f"Attempting to fetch open orders for account ID: {account_id}")
+        # This is a placeholder/simulation.
+        # A real implementation would query an endpoint like /api/Order/search
+        # with appropriate filters for status (e.g., "Working", "Pending", "Accepted").
+        # For now, returning an empty list to allow UI/endpoint structure development.
+        # Example of what a real call might look like:
+        # payload = {"accountId": account_id, "status": ["Working", "PendingNew"]} # Fictional status filter
+        # response_data = await self._request("POST", "/api/Order/search", payload=payload)
+        # then parse response_data into List[OpenOrderSchema]
+        logger.warning(f"SIMULATED: get_open_orders for account {account_id} returning empty list.")
+        await asyncio.sleep(0.1) # Simulate async behavior
+        return []
+        # Example of returning a dummy order for testing:
+        # return [OpenOrderSchema(id=12345, accountId=account_id, status="Working", contractId="CON.F.US.NQ.M25", side="buy", quantity=1)]
+
+    async def get_positions(self, account_id: int) -> List[PositionSchema]:
+        logger.info(f"Attempting to fetch positions for account ID: {account_id}")
+        # This is a placeholder/simulation.
+        # A real implementation would query an endpoint like /api/Position/search or /api/Position/all.
+        # For now, returning an empty list.
+        # Example of what a real call might look like:
+        # payload = {"accountId": account_id}
+        # response_data = await self._request("POST", "/api/Position/search", payload=payload)
+        # then parse response_data into List[PositionSchema]
+        logger.warning(f"SIMULATED: get_positions for account {account_id} returning empty list.")
+        await asyncio.sleep(0.1) # Simulate async behavior
+        return []
+        # Example of returning a dummy position for testing:
+        # return [PositionSchema(accountId=account_id, contractId="CON.F.US.NQ.M25", quantity=2, side="Long", averageEntryPrice=18000.0)]
 
     async def close(self):
         await self._client.aclose()

--- a/topstep_client/schemas.py
+++ b/topstep_client/schemas.py
@@ -80,3 +80,20 @@ class HistoricalBarsResponse(BaseSchema):
     # The API might wrap the list, e.g., {"data": {"bars": [...]}} or directly {"bars": [...]}
     # Or even just a direct list of bars. This needs to match the actual API response.
     # For now, assuming the API response is a list of bars directly or under a 'bars' key.
+
+class OpenOrderSchema(BaseSchema):
+    id: int
+    account_id: int = Field(..., alias="accountId")
+    status: str
+    # Add other fields if necessary, like contract_id, side, qty for display/logging
+    contract_id: Optional[str] = Field(default=None, alias="contractId")
+    side: Optional[str] = None
+    quantity: Optional[int] = Field(default=None, alias="qty")
+
+class PositionSchema(BaseSchema):
+    account_id: int = Field(..., alias="accountId")
+    contract_id: str = Field(..., alias="contractId")
+    quantity: float # Position quantity can be float for some asset types, or int
+    side: str # e.g., "Long", "Short" or "Buy", "Sell" - normalize if needed
+    # Add other fields like average_entry_price if available and needed
+    average_entry_price: Optional[float] = Field(default=None, alias="averageEntryPrice")


### PR DESCRIPTION
This commit introduces a new "Manual Trade Entry" page to the dashboard, allowing you to manually place orders and perform account-level actions.

Key changes:

1.  **Data Models (`main.py`):**
    *   Added `ManualTradeParams` Pydantic model for trade inputs (account ID,
        contract ID, side, size, trailing stop ticks).
    *   Added `AccountActionParams` Pydantic model for actions requiring an
        account ID.

2.  **Backend Endpoints for Orders (`main.py`):**
    *   `POST /manual/market_order`: Accepts `ManualTradeParams` and places
        a market order using `api_client.place_order()`.
    *   `POST /manual/trailing_stop_order`: Accepts `ManualTradeParams` and
        places a "TrailingStop" order.

3.  **Backend Endpoints for Account Actions (`main.py`):**
    *   `POST /manual/cancel_all_orders`: Accepts `AccountActionParams`.
        Calls a (currently simulated) `api_client.get_open_orders()` and
        then `api_client.cancel_order()` for each.
    *   `POST /manual/flatten_all_trades`: Accepts `AccountActionParams`.
        Calls a (currently simulated) `api_client.get_positions()` and
        then places opposing market orders to flatten each position.

4.  **API Client and Schema Updates (`topstep_client/`):**
    *   Added `OpenOrderSchema` and `PositionSchema` to `schemas.py`.
    *   Added simulated methods `get_open_orders()` and `get_positions()`
        to `api_client.py`. These return empty lists for now, allowing
        the frontend and endpoint structure to be built. Full implementation
        will require actual API calls.

5.  **Manual Trade Page (`main.py`):**
    *   `GET /manual_trade`: Serves an HTML page with a form for inputs:
        Account ID, Contract ID, Side, Size, Trailing Stop Ticks.
    *   Buttons on the page trigger JavaScript `fetch` calls to the new
        backend endpoints.
    *   A response area displays JSON results from the actions.

6.  **Menu Link (`main.py`):**
    *   Added a link to "/manual_trade" in the main dashboard menu.

This feature provides you with direct control for live testing and manual intervention. The "Cancel All" and "Flatten All" functionalities are structurally in place but rely on simulated API client methods that will need full implementation in the future.