### PR TITLE
Fix: Use numeric codes for order side and type

### DIFF
--- a/topstep_client/schemas.py
+++ b/topstep_client/schemas.py
@@ -37,8 +37,8 @@ class OrderRequest(BaseSchema):
     account_id: int = Field(..., alias='accountId')
     contract_id: str = Field(..., alias='contractId')
     quantity: int = Field(..., alias='qty')
-    side: str # "buy" or "sell"
-    type: str # "market", "limit", "stop", "TrailingStop"
+    side: int # Changed
+    type: int # Changed
     trailing_distance: Optional[int] = Field(default=None, alias="trailingDistance")
     limit_price: Optional[float] = Field(default=None, alias='limitPrice')
     stop_price: Optional[float] = Field(default=None, alias='stopPrice')


### PR DESCRIPTION
As per your clarification, the Topstep API expects numeric enum values for order 'side' and 'type' fields, not string representations like "Buy" or "market".

This commit implements the following changes:

1.  **Updated `OrderRequest` Schema (`topstep_client/schemas.py`):**
    - Changed `side: str` to `side: int`.
    - Changed `type: str` to `type: int`.

2.  **Updated Order Placement Logic (`main.py`):**
    - In `place_order_projectx` (webhook orders): - Converts `alert.signal` ("long"/"short") to `0` (Buy/Long) or `1` (Sell/Short). - Converts `alert.order_type` (string like "market", "limit", "stop", "TrailingStop") to numeric codes: Market=2, Limit=1 (assumed), Stop=3 (assumed), TrailingStop=5. Includes error handling for unknown string types.
    - In manual order endpoints (`post_manual_market_order`, `post_manual_trailing_stop_order`):
        - Converts `params.side` ("long"/"short") to `0` or `1`.
        - Sets order `type` to `2` for market orders and `5` for trailing stop orders.
    - In `close_position_projectx`: - Converts the determined closing side ("Buy"/"Sell") to `0` or `1`. - Sets order `type` to `2` (market order for closing).

The `SignalAlert` model in `main.py` continues to accept `signal` and `order_type` as strings from the webhook, with the conversion to numeric codes handled internally.

These changes should resolve API validation errors related to these fields and ensure orders are processed correctly.