### PR TITLE
I've made some changes to address the issues you pointed out:

### DIFF
--- a/main.py
+++ b/main.py
@@ -139,9 +139,9 @@ async def start_streams_if_needed():
 
         contract_id_to_subscribe = active_strategy_config.get("PROJECTX_CONTRACT_ID") or os.getenv("CONTRACT_ID") or "CON.F.US.NQ.M25"
         if contract_id_to_subscribe:
-            asyncio.create_task(market_stream.start())
-            market_stream.subscribe_contract(contract_id_to_subscribe)
-            logger.info(f"Market stream start initiated. Will subscribe to {contract_id_to_subscribe} on connect.")
+            # asyncio.create_task(market_stream.start()) # Commented out as per requirement
+            # market_stream.subscribe_contract(contract_id_to_subscribe) # Commented out as per requirement
+            logger.info(f"Market stream start and subscription are now deferred until explicitly needed by a trade for contract {contract_id_to_subscribe}.") # Updated log message
         else:
             logger.error("No contract ID configured for market data stream.")
 

--- a/topstep_client/schemas.py
+++ b/topstep_client/schemas.py
@@ -36,7 +36,7 @@ class Contract(BaseSchema):
 class OrderRequest(BaseSchema):
     account_id: int = Field(..., alias='accountId')
     contract_id: str = Field(..., alias='contractId')
-    quantity: int = Field(..., alias='qty')
+    quantity: int = Field(..., alias='size')
     side: int # Changed
     type: int # Changed
     trailing_distance: Optional[int] = Field(default=None, alias="trailingDistance")


### PR DESCRIPTION
1.  **MarketDataStream Dynamic Loading:**
    *   I've adjusted `main.py` so that `MarketDataStream` no longer automatically starts and subscribes to a contract when the application launches.
    *   Now, the stream is just initialized at startup. It will be fully started (connected and subscribed) by the existing `ensure_market_stream_for_contract` function when a trade activity (webhook or manual order) for a specific contract begins.
    *   It will also be stopped by `manage_market_stream_after_trade_close` if there are no active contract subscriptions left.

2.  **Manual Trade Entry Error:**
    *   I've updated the `OrderRequest` Pydantic model in `topstep_client/schemas.py`.
    *   I changed the alias of the `quantity` field from `qty` to `size`.
    *   This should fix the JSON deserialization error: "missing required properties including: 'size'" that was happening during manual trade entry. This change aligns the payload field name with what the API expects.