### PR TITLE
Fix: Correct OrderRequest instantiation for manual trades

### DIFF
--- a/main.py
+++ b/main.py
@@ -940,7 +940,7 @@ async def post_manual_market_order(params: ManualTradeParams, background_tasks: 
     order_req = OrderRequest(
         account_id=params.account_id,
         contract_id=params.contract_id,
-        qty=params.size,
+        quantity=params.size,
         side=order_side_numeric,
         type=2  # Market order type code
     )
@@ -982,7 +982,7 @@ async def post_manual_trailing_stop_order(params: ManualTradeParams, background_
     order_req = OrderRequest(
         account_id=params.account_id,
         contract_id=params.contract_id,
-        qty=params.size,
+        quantity=params.size,
         side=order_side_numeric,
         type=5,  # TrailingStop order type code
         trailing_distance=params.trailing_stop_ticks


### PR DESCRIPTION
Corrected the instantiation of the `OrderRequest` Pydantic model in `main.py` within the `post_manual_market_order` and `post_manual_trailing_stop_order` functions.

Changed from using `qty=params.size` to `quantity=params.size`.

This resolves a Pydantic validation error that occurred because the model was being initialized with a keyword (`qty`) that is neither the actual field name (`quantity`) nor an initialization-allowed alias. The field `quantity` is aliased to `size` for JSON serialization, which remains unchanged and correctly addresses the API's requirement for a `size` field in the payload.