### PR TITLE
Fix: Handle API order placement response correctly

### DIFF
--- a/topstep_client/api_client.py
+++ b/topstep_client/api_client.py
@@ -12,6 +12,7 @@ from .schemas import (
     Contract,
     OrderRequest,
     OrderDetails,
+    PlaceOrderResponse,
     APIResponse,
     ErrorDetail,
     BaseSchema,
@@ -235,9 +236,9 @@ class APIClient:
         except ValidationError as e:
             raise APIResponseParsingError("Failed to parse contract data.", raw_response_text=str(contracts_list_raw), original_exception=e) from e
 
-    async def place_order(self, order_request: OrderRequest) -> OrderDetails:
-        response_data = await self._request("POST", "/api/Order/place", payload=order_request, response_model=OrderDetails)
-        # The _request method with response_model=OrderDetails should handle parsing.
+    async def place_order(self, order_request: OrderRequest) -> PlaceOrderResponse:
+        response_data = await self._request("POST", "/api/Order/place", payload=order_request, response_model=PlaceOrderResponse)
+        # The _request method with response_model=PlaceOrderResponse should handle parsing.
         # However, the actual API response for order placement needs to be confirmed.
         # If it returns something like {"success": true, "orderId": 123, ...},
         # then OrderDetails model needs to match that, or response_data needs pre-processing here.

--- a/topstep_client/schemas.py
+++ b/topstep_client/schemas.py
@@ -56,6 +56,12 @@ class OrderDetails(BaseSchema):
     average_fill_price: Optional[float] = Field(default=None, alias='averageFillPrice')
     # Add other relevant fields
 
+class PlaceOrderResponse(BaseSchema):
+    order_id: int = Field(..., alias="orderId")
+    success: bool
+    error_code: Optional[int] = Field(default=None, alias="errorCode")
+    error_message: Optional[str] = Field(default=None, alias="errorMessage")
+
 class ErrorDetail(BaseSchema):
     error_code: Optional[str] = Field(default=None, alias='errorCode')
     error_message: Optional[str] = Field(default=None, alias='errorMessage')


### PR DESCRIPTION
I introduced a new Pydantic model `PlaceOrderResponse` to accurately represent the actual JSON response from the `/api/Order/place` endpoint. Previously, the system incorrectly expected a full `OrderDetails` object.

Changes include:
1.  **schemas.py**: I added the `PlaceOrderResponse` model with fields `orderId`, `success`, `errorCode`, and `errorMessage`.
2.  **api_client.py**:
    - I updated the `place_order` method to return `PlaceOrderResponse`.
    - I modified the `_request` call within `place_order` to use `response_model=PlaceOrderResponse` for parsing.
3.  **main.py**:
    - I updated functions calling `api_client.place_order` (including `place_order_projectx`, manual order endpoints, and trade closing functions) to expect `PlaceOrderResponse`.
    - I adjusted attribute access (e.g., `result.order_id` instead of `result.id`) and removed reliance on fields not present in `PlaceOrderResponse` for the immediate placement result.
    - I ensured `contract_id` for new `Trade` objects in `place_order_projectx` is sourced from your original request data, as it's not part of the placement response.

This resolves the `APIResponseParsingError` that occurred when the application tried to parse the simple success acknowledgement from the order placement API into the more complex `OrderDetails` model.