### PR TITLE
Fix: Change OrderRequest.trailing_distance alias to trailingStopTicks

### DIFF
--- a/topstep_client/schemas.py
+++ b/topstep_client/schemas.py
@@ -39,7 +39,7 @@ class OrderRequest(BaseSchema):
     quantity: int = Field(..., alias='size')
     side: int # Changed
     type: int # Changed
-    trailing_distance: Optional[int] = Field(default=None, alias="trailingDistance")
+    trailing_distance: Optional[int] = Field(default=None, alias="trailingStopTicks")
     limit_price: Optional[float] = Field(default=None, alias='limitPrice')
     stop_price: Optional[float] = Field(default=None, alias='stopPrice')
     # Add other relevant fields like time_in_force, etc.


### PR DESCRIPTION
The API was returning an error "Trail Distance not set." when placing trailing stop orders. This suggests a mismatch in the expected field name for the trailing distance parameter in the JSON payload.

This commit changes the Pydantic alias for the `trailing_distance` field in the `OrderRequest` schema from `trailingDistance` to `trailingStopTicks`. This new alias matches the incoming parameter name `trailingStopTicks` from `ManualTradeParams` and is a likely candidate for the field name expected by the API for order type 5 (Trailing Stop).