### PR TITLE
Fix: Export OrderSide enum from topstep_client package

### DIFF
--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -55,3 +55,10 @@ def test_order_request_serialization_without_trailing_distance():
     assert "trailDistance" not in request_dict
     assert "trailingStopTicks" not in request_dict
     assert "trailing_distance" not in request_dict
+
+
+def test_import_order_side_from_topstep_client():
+    from topstep_client import OrderSide
+
+    assert OrderSide.Bid == 0
+    assert OrderSide.Ask == 1

--- a/topstep_client/__init__.py
+++ b/topstep_client/__init__.py
@@ -18,6 +18,7 @@ from .schemas import (
     BaseSchema,
     BarData,
     HistoricalBarsResponse
+    OrderSide,
 )
 from .api_client import APIClient, get_authenticated_client
 
@@ -41,6 +42,7 @@ __all__ = [
     "BaseSchema",
     "BarData",
     "HistoricalBarsResponse",
+    "OrderSide",
 ]
 
 from .streams import StreamConnectionState, MarketDataStream, UserHubStream


### PR DESCRIPTION
The OrderSide enum was defined in topstep_client/schemas.py but not exported in topstep_client/__init__.py, causing an ImportError when you tried to import it from the topstep_client package.

This commit fixes the issue by:
- Adding OrderSide to the import list from .schemas in topstep_client/__init__.py.
- Adding OrderSide to the __all__ list in topstep_client/__init__.py.

I've also added a test to tests/test_schemas.py to specifically verify that OrderSide can be imported from the topstep_client package and that its members have the correct values.