### PR TITLE
Fix: Export OrderType, PositionType, and PositionModel

### DIFF
--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -62,3 +62,25 @@ def test_import_order_side_from_topstep_client():
 
     assert OrderSide.Bid == 0
     assert OrderSide.Ask == 1
+
+
+def test_import_order_type_from_topstep_client():
+    from topstep_client import OrderType
+
+    assert OrderType.Market == 2
+    assert OrderType.Limit == 1
+
+
+def test_import_position_type_from_topstep_client():
+    from topstep_client import PositionType
+
+    assert PositionType.Long == 1
+    assert PositionType.Short == 2
+
+
+def test_import_position_model_from_topstep_client():
+    from topstep_client import PositionModel
+    from pydantic import BaseModel
+
+    assert PositionModel is not None
+    assert issubclass(PositionModel, BaseModel)

--- a/topstep_client/__init__.py
+++ b/topstep_client/__init__.py
@@ -19,6 +19,9 @@ from .schemas import (
     BarData,
     HistoricalBarsResponse,
     OrderSide,
+    OrderType,
+    PositionType,
+    PositionModel,
 )
 from .api_client import APIClient, get_authenticated_client
 
@@ -43,6 +46,9 @@ __all__ = [
     "BarData",
     "HistoricalBarsResponse",
     "OrderSide",
+    "OrderType",
+    "PositionType",
+    "PositionModel",
 ]
 
 from .streams import StreamConnectionState, MarketDataStream, UserHubStream


### PR DESCRIPTION
This commit addresses ImportErrors for OrderType and ensures other potentially missing imports from topstep_client used in main.py are correctly exported.

Changes:
- Added OrderType, PositionType, and PositionModel to the import list from .schemas in topstep_client/__init__.py.
- Added OrderType, PositionType, and PositionModel to the __all__ list in topstep_client/__init__.py.
- Added tests in tests/test_schemas.py to verify that these can be imported from the topstep_client package and that their members/type are correct.

This ensures that main.py and other client code can successfully import these necessary components from the topstep_client package.